### PR TITLE
Fix bug where logged-out users' quiz results were not viewable

### DIFF
--- a/db/helpers/result_helpers.js
+++ b/db/helpers/result_helpers.js
@@ -11,7 +11,7 @@ const getAttemptData = function(attemptId, db) {
       quizzes.id AS quiz_id
     FROM attempts
       JOIN quizzes ON attempts.quiz_id = quizzes.id
-      JOIN users ON attempts.user_id = users.id
+      LEFT JOIN users ON attempts.user_id = users.id
       JOIN user_answers ON attempts.id = user_answers.attempt_id
       JOIN possible_answers ON user_answers.selected_answer = possible_answers.id
     WHERE attempts.id = $1


### PR DESCRIPTION
Changed JOIN to LEFT JOIN on helper query for results page linking attempts & users so that logged-out users (i.e. who we don't have a user for) can still view results page.