### PR TITLE
Results page fixes

### DIFF
--- a/db/helpers/result_helpers.js
+++ b/db/helpers/result_helpers.js
@@ -8,14 +8,15 @@ const getAttemptData = function(attemptId, db) {
       SUM(CASE WHEN possible_answers.is_correct = true THEN 1 ELSE 0 END) AS num_correct,
       COUNT(user_answers.*) AS num_total,
       ROUND((SUM(CASE WHEN possible_answers.is_correct = true THEN 1 ELSE 0 END)/1.00) / (COUNT(user_answers.*)/1.00)*100) AS percent_correct,
-      quizzes.id AS quiz_id
+      quizzes.id AS quiz_id,
+      attempts.id as attempt_id
     FROM attempts
       JOIN quizzes ON attempts.quiz_id = quizzes.id
       LEFT JOIN users ON attempts.user_id = users.id
       JOIN user_answers ON attempts.id = user_answers.attempt_id
       JOIN possible_answers ON user_answers.selected_answer = possible_answers.id
     WHERE attempts.id = $1
-    GROUP BY quizzes.title, quizzes.id, users.fname, users.lname, attempts.finished_at
+    GROUP BY quizzes.title, quizzes.id, users.fname, users.lname, attempts.id
   `;
   const queryParams = [attemptId];
   return db.query(queryString, queryParams)

--- a/public/scripts/result.js
+++ b/public/scripts/result.js
@@ -2,5 +2,19 @@
 
 $(() => {
 
+  //The below two code blocks handle the two copy-to-clipboard buttons on the results page:
+  $('.share.copyResultsLink').on('click', function() {
+    const attemptId = $(this).attr('id');
+    console.log("hi");
+    const string = `http://localhost:8080/result/${attemptId}`;
+    copyToClipboardAnyString(string);
+  })
+
+  $('.share.copyQuizLink').on('click', function() {
+    const quizId = $(this).attr('id');
+    console.log("hi");
+    const string = `http://localhost:8080/quiz/${quizId}`;
+    copyToClipboardAnyString(string);
+  })
 
 });

--- a/public/scripts/result.js
+++ b/public/scripts/result.js
@@ -1,0 +1,6 @@
+//The below line is shorthand for "$(document).ready(function () {"; it means the function won't be invoked until the page is loaded
+
+$(() => {
+
+
+});

--- a/public/scripts/user.js
+++ b/public/scripts/user.js
@@ -17,11 +17,13 @@ $(() => {
     $('#quiz').removeClass('active');
   });
 
+  //The below handles toggling between isPublic true and false by clicking the isPublic checkbox:
   $('tr td input[type="checkbox"]').on('click', function() {
     const quizId = $(this).parent().parent().attr('id');
     $.post(`/quiz/${quizId}/public`);
   });
 
+  //The below two blocks of code handle copy-to-clipboard for the quizzes-made and quizzes-taken tabs, respectively:
   $('.quizCopyButton').on('click', function() {
     const quizId = $(this).parent().parent().attr('id');
     const string = `http://localhost:8080/quiz/${quizId}`;

--- a/routes/result.js
+++ b/routes/result.js
@@ -18,6 +18,7 @@ const resultRouter = (db) => {
         loadWholeQuizJson(attemptId, db)
         .then(quizJson => {
           templateVars.quizJson = quizJson;
+          console.log(templateVars);
           res.render("../views/pages/result", templateVars);
         });
       } else {

--- a/views/pages/result.ejs
+++ b/views/pages/result.ejs
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/styles/quiz-display.css" />
   <link rel="stylesheet" href="/styles/buttons.css" />
   <%- include('../partials/_head-scripts.ejs'); %>
+  <script defer src="/scripts/app-functions.js"></script>
+  <script defer src="/scripts/result.js"></script>
 
   <title>QUOKKA? - <%= overallResults.title %> Results</title>
 </head>
@@ -19,7 +21,8 @@
       <p class="user-header"><%= overallResults.fname %> <%= overallResults.lname %>'s Results</p>
       <p class="score-header"><%= overallResults.percent_correct %>%</p>
       <p class="num-correct-header"''><%= overallResults.num_correct %> out of <%= overallResults.num_total %></p>
-      <a class="share" >Copy link to results </a>
+      <a class="share" >Copy Link to Results </a>
+      <a class="share" >Copy Link to Quiz </a>
     </section>
 
     <% for (const quizQuestion of quizJson) { %>

--- a/views/pages/result.ejs
+++ b/views/pages/result.ejs
@@ -18,7 +18,11 @@
   <main>
     <h2 class="quiz-title"><%= overallResults.title %></h2>
     <section>
-      <p class="user-header"><%= overallResults.fname %> <%= overallResults.lname %>'s Results</p>
+      <% if (overallResults.fname) { %>
+        <p class="user-header"><%= overallResults.fname %> <%= overallResults.lname %>'s Results</p>
+      <% } else { %>
+        <p class="user-header">Results</p>
+      <% } %>
       <p class="score-header"><%= overallResults.percent_correct %>%</p>
       <p class="num-correct-header"''><%= overallResults.num_correct %> out of <%= overallResults.num_total %></p>
       <a class="share copyResultsLink" id="<%= overallResults.attempt_id %>">Copy Link to Results </a>

--- a/views/pages/result.ejs
+++ b/views/pages/result.ejs
@@ -21,8 +21,8 @@
       <p class="user-header"><%= overallResults.fname %> <%= overallResults.lname %>'s Results</p>
       <p class="score-header"><%= overallResults.percent_correct %>%</p>
       <p class="num-correct-header"''><%= overallResults.num_correct %> out of <%= overallResults.num_total %></p>
-      <a class="share" >Copy Link to Results </a>
-      <a class="share" >Copy Link to Quiz </a>
+      <a class="share copyResultsLink" id="<%= overallResults.attempt_id %>">Copy Link to Results </a>
+      <a class="share copyQuizLink" id="<%= overallResults.quiz_id %>">Copy Link to Quiz </a>
     </section>
 
     <% for (const quizQuestion of quizJson) { %>


### PR DESCRIPTION
- Add copy-to-clipboard buttons on results page (results link & quiz link)
- Don't display name if at least first name doesn't exist. Instead, just say "Results"